### PR TITLE
#12583 выключить правило @stylistic/function-parentheses-space-inside для stylelint

### DIFF
--- a/stylelint/index.ts
+++ b/stylelint/index.ts
@@ -48,6 +48,7 @@ const config: Config = {
     'selector-no-qualifying-type': null,
     'selector-no-vendor-prefix': null,
     'value-no-vendor-prefix': null,
+    '@stylistic/function-parentheses-space-inside': null,
   },
 };
 


### PR DESCRIPTION
выключаем из за конфликтов с prettier
